### PR TITLE
Move ms-package to 'dependencies'

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
   "repository": "expressjs/serve-favicon",
   "dependencies": {
     "etag": "~1.2.0",
+    "ms": "0.6.2",
     "fresh": "0.2.2"
   },
   "devDependencies": {
     "istanbul": "0.3.0",
     "mocha": "~1.21.4",
-    "ms": "0.6.2",
     "proxyquire": "~1.0.1",
     "should": "~4.0.1",
     "supertest": "~0.13.0"


### PR DESCRIPTION
Move ms-package from 'devDependencies' to 'dependencies'. Course you always use it.

Otherwise I get:

```
Error: Cannot find module 'ms'
  at Function.Module._resolveFilename (module.js:338:15)
  at Function.Module._load (module.js:280:25)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at Object.<anonymous> (/home/zag2art/work/derbygen/node_modules/serve-favicon/index.js:16:10)
  at Module._compile (module.js:456:26)
```
