### PR TITLE
package: move `ms` to `dependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
   "repository": "expressjs/serve-favicon",
   "dependencies": {
     "etag": "~1.2.0",
-    "fresh": "0.2.2"
+    "fresh": "0.2.2",
+    "ms": "0.6.2"
   },
   "devDependencies": {
     "istanbul": "0.3.0",
     "mocha": "~1.21.4",
-    "ms": "0.6.2",
     "proxyquire": "~1.0.1",
     "should": "~4.0.1",
     "supertest": "~0.13.0"


### PR DESCRIPTION
Fix a bug introduced by 5cd483ee where the required module `ms`
was not installed in production.
