### PR TITLE
Set only actual headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,7 +145,9 @@ function send(req, res, icon) {
 
   // Set headers
   for (var header in headers) {
-    res.setHeader(header, headers[header]);
+    if (headers.hasOwnProperty(header)) {
+      res.setHeader(header, headers[header]);
+    }
   }
 
   if (fresh(req.headers, res._headers)) {


### PR DESCRIPTION
If we create a simple application, for example:

``` js
var express = require('express'),
    app = express(),
    compress = require('compression'),
    bodyParser = require('body-parser'),
    favicon = require('serve-favicon');

    app.use(compress());
    app.use(bodyParser.json());
    app.use(favicon(__dirname + '/public/img/favicon.png'));

    Object.prototype.example = function myExample () {
        console.log('I do not really have a plan.');
    };

app.listen(8000);
```

Application runs and everything is fine, so far. Now, if we try: `http://localhost:8000/favicon.ico` - Node throws an exception:

``` js
http.js:657
    value = value.replace(/[\r\n]+[ \t]*/g, '');
                  ^
TypeError: Object function myExample() {
    console.log('I do not really have a plan.');
} has no method 'replace'
```

Basically the `Object.prototype` has attached itself to the headers and the loop passes the whole function as a header.
The solution is the simple `.hasOwnProperty()` fix.
