### PR TITLE
Allow for more complex routing rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ module.exports = function favicon(path, options){
   }
 
   return function favicon(req, res, next){
-    if (parseUrl(req).pathname !== '/favicon.ico') {
+    if (parseUrl(req).pathname.indexOf('/favicon.ico') === -1) {
       next();
       return;
     }

--- a/test/test.js
+++ b/test/test.js
@@ -121,6 +121,13 @@ describe('favicon()', function(){
       .expect(200, done);
     });
 
+    it('should serve icon', function(done){
+      request(server)
+      .get('/somePath/favicon.ico')
+      .expect('Content-Type', 'image/x-icon')
+      .expect(200, done);
+    });
+
     it('should include cache-control', function(done){
       request(server)
       .get('/favicon.ico')


### PR DESCRIPTION
Our application has some complex routing logic that potentially will cause favicon requests to come in on a path other than the root. Its an old application that we're moving over, if this pull request doesn't make sense for the module thats alright we'll just continue to use the fork.