### PR TITLE
Added funcPath function

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,8 +84,8 @@ function favicon(path, options) {
       return;
     }
 
-    if (funcPath) {
-      path = funcPath(req, res);
+    if (pathFunc) {
+      path = pathFunc(req, res);
     }
     
     if (icon[path]) return send(req, res, icon[path]);   //This assumes that path is a unique key to lookup the icon in the cache.


### PR DESCRIPTION
Added an option to provide a function which determines the favicon path based on req and res. The function will be passed instead of path and must be of the form fn(req, res), returning a string.

Additionally, to support this, the icon cache has been converted to support caching of multiple icons.

Usage:
  app.use(favicon(function(req, res){ ... }));
